### PR TITLE
Fix example displaing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Otherwise, updating is simple, just cd into `$HOME/.npm-stats`, run git pull, an
 
 ### Examples
 
-```sh
+```
 $ npm-stats
 
 You've run npm install 8 times. For a total of 28 seconds.


### PR DESCRIPTION
sh mode interpreters `'` symbol as start of string and colorise it.
That looks a little bit weird on npm page

![screen shot 2015-11-05 at 5 52 48 pm](https://cloud.githubusercontent.com/assets/6943514/10973478/456b7e3e-83e6-11e5-88e7-173e87b2ef14.png)
